### PR TITLE
Use ruff for linting and error checking

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,20 +7,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
-  isort:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: jamescurtin/isort-action@master
-        with:
-            configuration: --check-only
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - name: Install dependencies
-        run: pip install flake8 flake8-pyproject
-      - name: Run flake8
-        run: flake8 .
+      - uses: chartboost/ruff-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,8 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.291
     hooks:
-      - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-pyproject
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,19 +79,17 @@
     minversion = "6.0"
     testpaths  = ["tests"]
 
-[tool.flake8]
-    ignore = [
-        "D1",   # Missing docstrings
-        "E203", # whitespace before ':' in slice (incompatible with black)
-        "E731", # Allow lambdas
-        "F405", # name undefined due to star imports
-        "W503", # line break before binary operator (incompatible with black)
-    ]
-    max-line-length = 99
-
-[tool.isort]
-    known_first_party = "sphinxcontrib_django"
-    # Approach Black compatibility (just run black after isort)
-    include_trailing_comma = true
-    line_length            = 88
-    multi_line_output      = 3
+[tool.ruff]
+  select = [
+    "F",
+    "E",
+    "W",
+    "I",
+    # "D",
+    "RET",
+    "SIM",
+  ]
+  ignore = [
+    "D1",   # Missing docstrings
+  ]
+  line-length = 99

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def do_autodoc():
     """
     This function simulates the autodoc functionality.
 
-    Taken from https://github.com/sphinx-doc/sphinx/blob/d635d94eebbca0ebb1a5402aa07ed58c0464c6d3/tests/test_ext_autodoc.py#L33-L45 # noqa: E501
+    Taken from https://github.com/sphinx-doc/sphinx/blob/d635d94eebbca0ebb1a5402aa07ed58c0464c6d3/tests/test_ext_autodoc.py#L33-L45
     """
 
     def do_autodoc(app, objtype, name, options=None):


### PR DESCRIPTION
Ruff integrating flake8, many of its plugins and isort all into a single program. It's substantially faster, can auto-fix some types of errors, and allows enabling additional checks in future.

Needs: https://github.com/edoburu/sphinxcontrib-django/pull/48